### PR TITLE
Stats and scoreboard

### DIFF
--- a/src/DiscordBot.java
+++ b/src/DiscordBot.java
@@ -177,7 +177,7 @@ public class DiscordBot {
 		cmdHandler.registerCommand(new CommandLink());
 		cmdHandler.registerCommand(new CommandLinkServer());
 		cmdHandler.registerCommand(new CommandLinkHelp());
-		//cmdHandler.registerCommand(new CommandStats());
+		cmdHandler.registerCommand(new CommandStats());
 		cmdHandler.registerCommand(new CommandPlayerInfo());
 		cmdHandler.registerCommand(new CommandRefreshServers());
 		cmdHandler.registerCommand(new CommandScramble());

--- a/src/GatherObject.java
+++ b/src/GatherObject.java
@@ -90,7 +90,7 @@ public class GatherObject
 		setQueueRole(DiscordBot.client.getRoleByID(queueRoleID));
 		setSoftQueueRole(DiscordBot.client.getRoleByID(softQueueRoleID));
 
-		if(scoreboardChannelID!=0 && scoreboardMessageID==0)
+		if(scoreboardChannelID!=0)
 		{
 			IChannel chan = DiscordBot.client.getChannelByID(scoreboardChannelID);
 			if(chan == null)
@@ -98,14 +98,14 @@ public class GatherObject
 				Discord4J.LOGGER.warn("Error getting scoreboard channel, null returned");
 				return;
 			}
-			scoreboardMessageID = chan.sendMessage("scoreboard").getLongID();
-			setScoreboardMessage(DiscordBot.client.getMessageByID(scoreboardMessageID));
-			this.updateScoreboard();
-			System.out.println("new scoreboard message has been created, please enter the message id in the config or a scoreboard will be created each time the bot starts: "+scoreboardMessageID);
-		}
-		else
-		{
-			setScoreboardMessage(DiscordBot.client.getMessageByID(scoreboardMessageID));
+
+			if(scoreboardMessageID==0)
+			{
+				scoreboardMessageID = chan.sendMessage("scoreboard").getLongID();
+				System.out.println("new scoreboard message has been created, please enter the message id in the config or a scoreboard will be created each time the bot starts: "+scoreboardMessageID);
+			}
+
+			setScoreboardMessage(chan.fetchMessage(scoreboardMessageID));
 		}
 
 		if(this.getScoreboardMessage()!=null)this.updateScoreboard();


### PR DESCRIPTION
- Re-enabled !stats command
- Fixed bot unable to get scoreboard message
  - Changed [IDiscordClient.getMessageByID()](https://static.javadoc.io/com.discord4j/Discord4J/2.10.1/sx/blah/discord/api/IDiscordClient.html#getMessageByID-long-) to [IChannel.fetchMessage()](https://static.javadoc.io/com.discord4j/Discord4J/2.10.1/sx/blah/discord/handle/obj/IChannel.html#fetchMessage-long-)